### PR TITLE
Removing the email step to get the public key.

### DIFF
--- a/config_br.xml
+++ b/config_br.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<module>
+	<name>mercadopagobr</name>
+	<displayName><![CDATA[MercadoPago Brasil]]></displayName>
+	<version><![CDATA[3.0.4]]></version>
+	<description><![CDATA[Receba pagamentos via MercadoPago de cart&otilde;es de cr&eacute;ditos e boletos utlizando nosso checkout transparente ou standard.]]></description>
+	<author><![CDATA[MERCADOPAGO.COM REPRESENTA&Ccedil;&Otilde;ES LTDA.]]></author>
+	<tab><![CDATA[payments_gateways]]></tab>
+	<confirmUninstall><![CDATA[Você tem certeza que deseja desinstalar MercadoPago?]]></confirmUninstall>
+	<is_configurable>1</is_configurable>
+	<need_instance>0</need_instance>
+	<limited_countries></limited_countries>
+</module>

--- a/includes/mercadopago.php
+++ b/includes/mercadopago.php
@@ -28,7 +28,7 @@ $GLOBALS['LIB_LOCATION'] = dirname(__FILE__);
 
 class MP {
 
-	const VERSION = '3.0.3';
+	const VERSION = '3.0.4';
 
 	private $client_id;
 	private $client_secret;

--- a/mercadopagobr.php
+++ b/mercadopagobr.php
@@ -36,7 +36,7 @@ class MercadoPagoBr extends PaymentModule {
 	{
 		$this->name = 'mercadopagobr';
 		$this->tab = 'payments_gateways';
-		$this->version = '3.0.3';
+		$this->version = '3.0.4';
 		$this->currencies = true;
 		$this->currencies_mode = 'radio';
 		$this->need_instance = 0;

--- a/translations/br.php
+++ b/translations/br.php
@@ -16,8 +16,6 @@ $_MODULE['<{mercadopagobr}prestashop>mercadopagobr_ab74c3411f6f46df16a6c47791be5
 $_MODULE['<{mercadopagobr}prestashop>mercadopagobr_bf40a1c10d0b4a9cb26a27593226285b'] = 'Transação em Mediação';
 $_MODULE['<{mercadopagobr}prestashop>mercadopagobr_53b4d02529d11ed85eb327d5297ec1ca'] = 'Transação Pendente';
 $_MODULE['<{mercadopagobr}prestashop>mercadopagobr_78086b44061cc166428738759175358b'] = 'Client id ou client secret inválidos';
-$_MODULE['<{mercadopagobr}prestashop>mercadopagobr_193b67c29f909c34ee2ef62bf9fcf76e'] = 'Public Key inválida.';
-$_MODULE['<{mercadopagobr}prestashop>mercadopagobr_6ee85fcd774802d86e4388cb833a6806'] = 'O modo Standard não pode ser habilitado juntamente com o modo Transparente.';
 $_MODULE['<{mercadopagobr}prestashop>mercadopagobr_d224cb7eb307183325b7e5657d149075'] = 'Habilite pelo menos um método de pagamento.';
 $_MODULE['<{mercadopagobr}prestashop>marketing_142f1c01254127506592cf5e94910369'] = 'MercadoPago';
 $_MODULE['<{mercadopagobr}prestashop>marketing_1a6d2a8ff2319210efdf5327a1de772e'] = 'A maneira mais fácil, rápida e segura';
@@ -65,14 +63,10 @@ $_MODULE['<{mercadopagobr}prestashop>marketing_655359b12da649a1fc7c885daf1f9ccb'
 $_MODULE['<{mercadopagobr}prestashop>marketing_70ab2d4bdda3f1de777775e0811da197'] = 'Crie uma conta no MercadoPago';
 $_MODULE['<{mercadopagobr}prestashop>marketing_bf733d8a933c1601697f364223fc7ecb'] = 'Acesse';
 $_MODULE['<{mercadopagobr}prestashop>marketing_3aa1cdaa33b7ee8f3551c59da50f07c1'] = 'Copie o código do “Client_id” e do “Client_secret”';
-$_MODULE['<{mercadopagobr}prestashop>marketing_33ac0489f7f1f245e0d95be3c2be7cb4'] = 'Será necessário criar uma “Public_Key”';
-$_MODULE['<{mercadopagobr}prestashop>marketing_85c4eb5d19c089517070fa448e755af1'] = '1. Envie um e-mail para';
-$_MODULE['<{mercadopagobr}prestashop>marketing_9a63b11a00d15ca451c7d371793b5ba0'] = 'informando o seu “Cliente_ID” e a Plataforma “PrestaShop”';
-$_MODULE['<{mercadopagobr}prestashop>marketing_1b5cea716b533ccca12abcc05e5069fc'] = '2. Em até 1 dia útil, seu e-mail será respondido com a sua “Public_Key”';
-$_MODULE['<{mercadopagobr}prestashop>marketing_a7dbe3fe0159753ef17b2d8168e154ba'] = '3. Verifique na sua caixa de Spam, se necessário';
+$_MODULE['<{mercadopagobr}prestashop>marketing_0c100fe9a6e33fe0e15e85436ea51775'] = 'Você precisa ativar sua \"Public_key\" de produção';
+$_MODULE['<{mercadopagobr}prestashop>marketing_6d865742d3f3c489f7266da6bd29acb0'] = 'Para ativar, acesse';
 $_MODULE['<{mercadopagobr}prestashop>marketing_03019c6090f6856c3416490d5ed88ff5'] = 'Na página da Plataforma PrestaShop, acesse a página de configuração do Módulo MercadoPago';
-$_MODULE['<{mercadopagobr}prestashop>marketing_c5fa40a5a001d2b1abbbaa49d5f94442'] = 'Preencha os campos “Client_ID” e “Client_Secret”';
-$_MODULE['<{mercadopagobr}prestashop>marketing_cb409e39efb7ce447fa1e35b56d6602a'] = 'Preencha o campo “Public_Key” que você criou e recebeu por e-mail';
+$_MODULE['<{mercadopagobr}prestashop>marketing_10b3bfb2a0b102069d39c0d7de4131b2'] = 'Preencha os campos \"Client Id\", \"Client Secret\" e \"Public Key\"';
 $_MODULE['<{mercadopagobr}prestashop>marketing_eaa87f9f18cc89c620f024301b89abca'] = 'Clique em “Atualizar”';
 $_MODULE['<{mercadopagobr}prestashop>marketing_63a3be538fa32aa02cda5c7acc5c2430'] = 'Pronto!';
 $_MODULE['<{mercadopagobr}prestashop>marketing_61c2b0daf557503525cb74fd143b14c1'] = 'Nunca foi tão fácil vender!';
@@ -84,7 +78,7 @@ $_MODULE['<{mercadopagobr}prestashop>settings_5d4646d84c32dfa4d963c7c41b7799ca']
 $_MODULE['<{mercadopagobr}prestashop>settings_8c66220ba3229322899c260c7586714a'] = 'As configurações não foram atualizadas com sucesso.';
 $_MODULE['<{mercadopagobr}prestashop>settings_2a01d572b1447155c310cabafac3fae9'] = 'Observações:';
 $_MODULE['<{mercadopagobr}prestashop>settings_cfef100e3f47603e51eff1ccb33d6046'] = '- Para obter seu Cliend Id e Client Secret por favor acesse:';
-$_MODULE['<{mercadopagobr}prestashop>settings_150c044019aeb709532ce211158cacfa'] = '- Para obter sua Public Key, por favor envie um email para developers@mercadopago.com.br com o assunto \"Prestashop Public Key\" informando o seu Client Id';
+$_MODULE['<{mercadopagobr}prestashop>settings_f7256f8581b8acaec8de726092b05c6a'] = '- Para obter e ativar a sua Public Key modo de produção, por favor, siga os passos em \"O que preciso para ir a produção?\" e \"Eu quero ir para produção\" encontrados em: ';
 $_MODULE['<{mercadopagobr}prestashop>settings_9a82a186e7652aa9dd2b9b66d07eb6e3'] = 'Configurações - Geral';
 $_MODULE['<{mercadopagobr}prestashop>settings_c3094c38b5d23f8ce7a82fed39c7b3a6'] = 'Client Id:';
 $_MODULE['<{mercadopagobr}prestashop>settings_ba49bdb9b152ac018e612128714909ce'] = 'Client Secret:';
@@ -116,7 +110,7 @@ $_MODULE['<{mercadopagobr}prestashop>settings_7d6e7dae64188098604a9f9ec407f782']
 $_MODULE['<{mercadopagobr}prestashop>settings_25e02e7fa8a60bc58e3e05349006fcc8'] = 'Ativado:';
 $_MODULE['<{mercadopagobr}prestashop>settings_93cba07454f06a4a960172bbd6e2a435'] = 'Sim';
 $_MODULE['<{mercadopagobr}prestashop>settings_bafd7322c6e97d25b6299b5d6fe8920b'] = 'Não';
-$_MODULE['<{mercadopagobr}prestashop>settings_82221cf0a72f7da991c172d97764f1ee'] = 'Public Key:';
+$_MODULE['<{mercadopagobr}prestashop>settings_190ead988d0c96958323648e8f536e26'] = 'Public Key de Produção:';
 $_MODULE['<{mercadopagobr}prestashop>settings_f0a279d8944ba3f4c969d1928dfb6265'] = 'Banner:';
 $_MODULE['<{mercadopagobr}prestashop>settings_4995e326b2561371b4aa448631423599'] = 'Configurações - Boleto Transparente';
 $_MODULE['<{mercadopagobr}prestashop>settings_2add6f4e140bc0631f2584ecedf042ab'] = 'Configurações - MercadoPago Standard';

--- a/views/templates/admin/marketing.tpl
+++ b/views/templates/admin/marketing.tpl
@@ -222,11 +222,11 @@
 						</div>
 						<div>
 							<span class="icon i-bullet-1"></span>
-							<h5>{l s='You must create a "Public_key"' mod='mercadopagobr'}</h5>
+							<h5>{l s='You must activate your production "Public_key"' mod='mercadopagobr'}</h5>
 							<ul>
-								<li>{l s='1. Send an email to' mod='mercadopagobr'}<a href="mailto:developers@mercadopago.com.br" target="_blank"><strong> developers@mercadopago.com.br</strong></a> {l s='informing your "Client_id" and Prestashop as platform' mod='mercadopagobr'}</li>
-								<li>{l s='2. Until 1 working day your email will be answered with your "Public_key' mod='mercadopagobr'}</li>
-								<li>{l s='3. Verify your spam box if necessary' mod='mercadopagobr'}</li>
+								<li>{l s='To activate access ' mod='mercadopagobr'}
+									<a href="https://www.mercadopago.com/mlb/account/credentials" target="_blank"><strong class="font-2">https://www.mercadopago.com/mlb/account/credentials</strong></a>
+								</li>
 							</ul>
 						</div>
 						<div>
@@ -237,11 +237,7 @@
 						<div>
 							<span class="icon i-bullet-2"></span>
 							<span class="icon i-bullet-1"></span>
-							<h5>{l s='Fill the fields "Client Id" and "Client Secret"' mod='mercadopagobr'}</h5>
-						</div>
-						<div>
-							<span class="icon i-bullet-1"></span>
-							<h5>{l s='Fill the field "Public Key" that you received via email' mod='mercadopagobr'}</h5>
+							<h5>{l s='Fill the fields "Client Id", "Client Secret" and "Public Key"' mod='mercadopagobr'}</h5>
 						</div>
 						<div>
 							<span class="icon i-bullet-2"></span>

--- a/views/templates/admin/settings.tpl
+++ b/views/templates/admin/settings.tpl
@@ -76,7 +76,9 @@
 	<h4> {l s='- To obtain your Client Id and Client Secret please access: ' mod='mercadopagobr'}
 		<a href="https://www.mercadopago.com/mlb/ferramentas/aplicacoes"><u>https://www.mercadopago.com/mlb/ferramentas/aplicacoes</u></a>
 	</h4>
-	<h4> {l s='- To obtain your public key please send an email to developers@mercadopago.com.br with subject "Prestashop Public key" informing your Client Id' mod='mercadopagobr'}</h4>
+	<h4> {l s='- To get and activate your production public_key, please follow the steps "What do I need to go to production?" and "I want to go to production" in the following address: ' mod='mercadopagobr'}
+		<a href="https://www.mercadopago.com/mlb/account/credentials">https://www.mercadopago.com/mlb/account/credentials</a>
+	</h4>
 	<form action="{$uri|escape:'htmlall'}" method="post">
 		<fieldset>
 			<legend>
@@ -133,7 +135,7 @@
 				</select>
 			</div>
 			<br />
-			<label>{l s='Public Key:' mod='mercadopagobr'}</label>
+			<label>{l s='Production Public Key:' mod='mercadopagobr'}</label>
 			<div class="">
 				<input type="text" size="33" name="MERCADOPAGO_PUBLIC_KEY" value="{$public_key|escape:'htmlall'}" />
 			</div>


### PR DESCRIPTION
Now the merchant needs just to follow a few steps to activate and get
the public key - this will make the faster the activation of checkout
custom